### PR TITLE
Fix typo on `rev` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Add this to your `.pre-commit-config.yaml`
 
 ```yaml
 -   repo: https://github.com/conorfalvey/check_pdb_hook
-    rev: v0.0.9
+    rev: 0.0.9
     hooks:
     -   id: check_pdb_hook
 ```


### PR DESCRIPTION
After including the hook on `.pre-commit-config.yaml` I get the following error:

```
$ pre-commit run check_pdb_hook
[INFO] Initializing environment for https://github.com/conorfalvey/check_pdb_hook.
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/git', 'checkout', 'v0.0.9')
return code: 1
expected return code: 0
stdout: (none)
stderr:
    error: pathspec 'v0.0.9' did not match any file(s) known to git
    
Check the log at .cache/pre-commit/pre-commit.log

```

**PROBLEM** There is a typo on README.md: extra `v` on `rev` parameter.

## Steps to reproduce the issue and test the patch:
1. Add hook to your `.pre-commit-config.yaml`
2. Run: `pre-commit install`
3. Run manually pre-commit: `pre-commit run check_pdb_hook`